### PR TITLE
add HSB colorMode ranges for saturation and brightness

### DIFF
--- a/visualMode/public/sketch.js
+++ b/visualMode/public/sketch.js
@@ -28,7 +28,7 @@ function preload(){
 
 function setup() {
   createCanvas(windowWidth, windowHeight);
-  colorMode(HSB, 360);
+  colorMode(HSB, 360, 100, 100);
   setInterval(getState, 500);
 }
 


### PR DESCRIPTION
Thanks for updating the HSB hue range to 360. I noticed that the saturation and brightness levels are low so I adjusted colorMode setting on sketch.js to colorMode(HSB, 360, 100, 100). 

Try it with this example: https://editor.p5js.org/enickles/sketches/BJpe-BQgE